### PR TITLE
fix: 인스타그램 연동 수정

### DIFF
--- a/src/main/java/com/onmarket/member/domain/Member.java
+++ b/src/main/java/com/onmarket/member/domain/Member.java
@@ -131,7 +131,7 @@ public class Member extends BaseTimeEntity {
 
     /** Instagram 연결 여부 확인 */
     public boolean hasInstagramConnected() {
-        return this.instagramAccessToken != null && !this.instagramAccessToken.trim().isEmpty();
+        return this.instagramUsername!= null && !this.instagramUsername.trim().isEmpty();
     }
 
     /** 표시용 Instagram 계정명 반환 (@ 포함) */


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #58 \
## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!


Instagram 연동 상태 조회 500 에러 해결

Member.hasInstagramConnected() 메서드 로직 수정
instagramAccessToken 대신 instagramUsername 필드로 연동 상태 판단하도록 변경

상세 변경 사항
수정 전: instagramAccessToken을 체크하여 연동 상태 확인 (항상 null이므로 false 반환)
수정 후: instagramUsername을 체크하여 연동 상태 확인 (실제 저장되는 값으로 정확한 판단)

해결된 문제
새로고침 시 Instagram 연동 상태가 초기화되는 문제 해결
/api/instagram/status API 500 에러 해결
사용자 경험 개선: 연동 후 페이지 새로고침해도 연동 상태 유지

## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-